### PR TITLE
Add "Type Character" command using SendKeys

### DIFF
--- a/CharacterMapExtension/CharacterMapExtension.csproj
+++ b/CharacterMapExtension/CharacterMapExtension.csproj
@@ -69,6 +69,7 @@
 
     <!-- When publishing trimmed, make sure to treat trimming warnings as build errors -->
     <ILLinkTreatWarningsAsErrors>true</ILLinkTreatWarningsAsErrors>
+    <UseWindowsForms>True</UseWindowsForms>
 
   </PropertyGroup>
 

--- a/CharacterMapExtension/Commands/TypeCharacter.cs
+++ b/CharacterMapExtension/Commands/TypeCharacter.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace CharacterMapExtension.Commands
+{
+    internal partial class TypeCharacter : InvokableCommand
+    {
+        private readonly string _char;
+        private const int WAIT_TIME = 250;
+
+        public TypeCharacter(string ch)
+        {
+            Name = "Place";
+            _char = ch;
+        }
+
+        public override ICommandResult Invoke()
+        {
+            var _ = Task.Run(() =>
+            {
+                Thread.Sleep(WAIT_TIME);
+                SendKeys.SendWait(_char);
+            });
+
+            return CommandResult.Hide();
+        }
+    }
+}

--- a/CharacterMapExtension/Pages/CharacterMapExtensionPage.cs
+++ b/CharacterMapExtension/Pages/CharacterMapExtensionPage.cs
@@ -64,6 +64,10 @@ internal sealed partial class CharacterMapExtensionPage : ListPage
             Icon = new IconInfo(item.symbol.Symbol),
             Command = new CopyToClipboard(item.symbol.Symbol),
             MoreCommands = [
+                new CommandContextItem(new TypeCharacter(item.symbol.Symbol)) {
+                    Title = "Type Character",
+                    RequestedShortcut = new KeyChord() { Vkey = (int)VirtualKey.Enter, Modifiers = VirtualKeyModifiers.Control }
+                },
                 new CommandContextItem(new CopyToClipboard(item.symbol.Unicode)) {
                     Title = "Copy Unicode",
                     RequestedShortcut = new KeyChord() { Vkey = (int)VirtualKey.U, Modifiers = VirtualKeyModifiers.Control }


### PR DESCRIPTION
Added a new TypeCharacter command that sends the selected character as keystrokes via SendKeys.SendWait, accessible from the command palette with Ctrl+Enter. Enabled Windows Forms support in the project to support this functionality.